### PR TITLE
Make popovers dismissable on outside click

### DIFF
--- a/crates/demo/src/demos/date_picker_demo.rs
+++ b/crates/demo/src/demos/date_picker_demo.rs
@@ -11,7 +11,7 @@ use crate::{
     components::{
         calendar::calendar,
         icon::{icon, IconName},
-        popover::popover,
+        popover::popover_dismissable,
     },
     demos::common::{section_caption, section_title},
     theme::AppTheme,
@@ -73,7 +73,7 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
     iced::widget::column![
         section_title(theme, "Date picker"),
         section_caption(theme, "Click the field to open the calendar. Pick a day to close it."),
-        popover(theme, trigger, panel),
+        popover_dismissable(theme, trigger, panel, Message::DatePickerToggle),
     ]
     .spacing(10)
     .into()

--- a/crates/iced-longbridge/src/components/color_picker.rs
+++ b/crates/iced-longbridge/src/components/color_picker.rs
@@ -8,8 +8,7 @@ use iced::{
 use palette::{FromColor, Hsl, IntoColor, Srgb};
 
 use crate::{
-    components::popover::popover,
-    styles,
+    components::popover::popover_dismissable,
     theme::AppTheme,
 };
 
@@ -28,7 +27,7 @@ pub fn color_picker<'a, Message: Clone + 'a>(
     let panel = open.then(|| {
         panel(theme, value, hex_draft, on_change, on_hex_change)
     });
-    popover(theme, trigger, panel)
+    popover_dismissable(theme, trigger, panel, on_toggle)
 }
 
 /// Just the 32×32 colored swatch without any popover behaviour. Useful in
@@ -155,7 +154,9 @@ fn panel<'a, Message: Clone + 'a>(
         row![
             swatch(theme, value),
             container(hex_field).width(Length::Fixed(120.0)),
-            text(format_hex(value)).size(12.0).color(t.muted_foreground),
+            container(text(format_hex(value)).size(12.0).color(t.muted_foreground))
+                .height(Length::Fill)
+                .align_y(Vertical::Center),
         ]
         .spacing(8)
         .align_y(Vertical::Center),
@@ -163,9 +164,8 @@ fn panel<'a, Message: Clone + 'a>(
     .spacing(10);
 
     container(body)
-        .padding(Padding::from([16.0, 16.0]))
+        .padding(Padding::from([10.0, 10.0]))
         .width(Length::Fixed(PANEL_WIDTH))
-        .style(move |_| styles::popover_container(&t, 10.0))
         .into()
 }
 

--- a/crates/iced-longbridge/src/components/dropdown_button.rs
+++ b/crates/iced-longbridge/src/components/dropdown_button.rs
@@ -10,7 +10,7 @@ use crate::{
     components::{
         icon::{icon, IconName},
         menu::{menu, Item},
-        popover::popover,
+        popover::popover_dismissable,
     },
     theme::{AppTheme, Size},
 };
@@ -51,7 +51,7 @@ pub fn dropdown_button_sized<'a, Message: Clone + 'a>(
     )
     .padding(Padding::from([0.0, px]))
     .height(iced::Length::Fixed(h))
-    .on_press(on_toggle)
+    .on_press(on_toggle.clone())
     .style(move |_, status| {
         use button::Status::*;
         let (bg, fg) = match status {
@@ -73,5 +73,5 @@ pub fn dropdown_button_sized<'a, Message: Clone + 'a>(
     });
 
     let menu_panel = open.then(|| menu(theme, items));
-    popover(theme, trigger.into(), menu_panel)
+    popover_dismissable(theme, trigger.into(), menu_panel, on_toggle)
 }

--- a/crates/iced-longbridge/src/components/floating_panel.rs
+++ b/crates/iced-longbridge/src/components/floating_panel.rs
@@ -1,11 +1,10 @@
 //! Floating panel — a trigger with an optional panel that renders as a true
-//! overlay below it.
+//! overlay anchored below (or above, if space is tight) the trigger.
 //!
-//! Unlike [`popover`](super::popover), which renders the panel inline in a
-//! column (and therefore pushes surrounding layout), this widget returns the
-//! panel via `Widget::overlay()` so it floats over other content instead of
-//! claiming vertical space. Used by [`menu_bar`](super::menu_bar) so opening
-//! one menu doesn't shift the other triggers down.
+//! The panel is returned via `Widget::overlay()` so it floats over other
+//! content instead of claiming layout space. Used directly by
+//! [`menu_bar`](super::menu_bar) and through [`popover`](super::popover) by
+//! the dropdown button, color picker, time picker, and date picker.
 
 use iced::{
     Element, Event, Length, Rectangle, Size, Vector,
@@ -29,6 +28,7 @@ where
     gap: f32,
     align: Horizontal,
     flip: bool,
+    on_dismiss: Option<Message>,
 }
 
 impl<'a, Message, Theme, Renderer> FloatingPanel<'a, Message, Theme, Renderer>
@@ -45,6 +45,7 @@ where
             gap: 4.0,
             align: Horizontal::Left,
             flip: true,
+            on_dismiss: None,
         }
     }
 
@@ -66,11 +67,20 @@ where
         self.flip = flip;
         self
     }
+
+    /// Fire `message` when the user presses the mouse outside the panel.
+    /// Typical use: pass the same message that toggles the panel open, so a
+    /// click anywhere else closes it.
+    pub fn on_dismiss(mut self, message: Message) -> Self {
+        self.on_dismiss = Some(message);
+        self
+    }
 }
 
 impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for FloatingPanel<'_, Message, Theme, Renderer>
 where
+    Message: Clone,
     Renderer: iced::advanced::Renderer,
 {
     fn children(&self) -> Vec<Tree> {
@@ -212,6 +222,7 @@ where
                     gap: self.gap,
                     align: self.align,
                     flip: self.flip,
+                    on_dismiss: self.on_dismiss.as_ref(),
                 })))
             }
             _ => None,
@@ -230,7 +241,7 @@ where
 impl<'a, Message, Theme, Renderer> From<FloatingPanel<'a, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
-    Message: 'a,
+    Message: Clone + 'a,
     Theme: 'a,
     Renderer: iced::advanced::Renderer + 'a,
 {
@@ -249,11 +260,13 @@ where
     gap: f32,
     align: Horizontal,
     flip: bool,
+    on_dismiss: Option<&'b Message>,
 }
 
 impl<Message, Theme, Renderer> Overlay<Message, Theme, Renderer>
     for PanelOverlay<'_, '_, Message, Theme, Renderer>
 where
+    Message: Clone,
     Renderer: iced::advanced::Renderer,
 {
     fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
@@ -279,12 +292,13 @@ where
         let max_x = (bounds.width - panel_size.width).max(0.0);
         let x = x.clamp(0.0, max_x);
 
+        // Flip above only when the above position fits entirely; otherwise
+        // keep the panel below so it never overlaps the trigger. If it's
+        // taller than the viewport, the overlay will clip at the edge.
         if self.flip && y + panel_size.height > bounds.height {
             let flipped = self.trigger_bounds.y - self.gap - panel_size.height;
             if flipped >= 0.0 {
                 y = flipped;
-            } else {
-                y = (bounds.height - panel_size.height).max(0.0);
             }
         }
 
@@ -324,6 +338,20 @@ where
         self.panel.as_widget_mut().update(
             self.tree, event, layout, cursor, renderer, clipboard, shell, &viewport,
         );
+
+        // Dismiss on a mouse press that lands outside both the panel and the
+        // trigger. Excluding the trigger avoids double-toggling when the
+        // trigger button itself is used to close the panel.
+        if let (Some(dismiss), Event::Mouse(mouse::Event::ButtonPressed(_))) =
+            (self.on_dismiss, event)
+        {
+            let hit = cursor.position().is_some_and(|p| {
+                layout.bounds().contains(p) || self.trigger_bounds.contains(p)
+            });
+            if !hit {
+                shell.publish(dismiss.clone());
+            }
+        }
     }
 
     fn mouse_interaction(

--- a/crates/iced-longbridge/src/components/popover.rs
+++ b/crates/iced-longbridge/src/components/popover.rs
@@ -12,19 +12,32 @@ use iced::{
 
 use crate::{components::floating_panel::FloatingPanel, theme::AppTheme};
 
-pub fn popover<'a, Message: 'a>(
+pub fn popover<'a, Message: Clone + 'a>(
     theme: &AppTheme,
     trigger: Element<'a, Message>,
     panel: Option<Element<'a, Message>>,
 ) -> Element<'a, Message> {
-    popover_aligned(theme, trigger, panel, Horizontal::Left)
+    popover_aligned(theme, trigger, panel, Horizontal::Left, None)
 }
 
-pub fn popover_aligned<'a, Message: 'a>(
+/// Like [`popover`], but also closes the panel when the user clicks outside
+/// it (the `on_dismiss` message fires on any mouse press beyond the panel's
+/// bounds — typically the same message that toggled it open).
+pub fn popover_dismissable<'a, Message: Clone + 'a>(
+    theme: &AppTheme,
+    trigger: Element<'a, Message>,
+    panel: Option<Element<'a, Message>>,
+    on_dismiss: Message,
+) -> Element<'a, Message> {
+    popover_aligned(theme, trigger, panel, Horizontal::Left, Some(on_dismiss))
+}
+
+pub fn popover_aligned<'a, Message: Clone + 'a>(
     theme: &AppTheme,
     trigger: Element<'a, Message>,
     panel: Option<Element<'a, Message>>,
     align: Horizontal,
+    on_dismiss: Option<Message>,
 ) -> Element<'a, Message> {
     let t = *theme;
     let wrapped = panel.map(|p| {
@@ -44,5 +57,9 @@ pub fn popover_aligned<'a, Message: 'a>(
             .into()
     });
 
-    FloatingPanel::new(trigger, wrapped).align(align).into()
+    let mut fp = FloatingPanel::new(trigger, wrapped).align(align);
+    if let Some(msg) = on_dismiss {
+        fp = fp.on_dismiss(msg);
+    }
+    fp.into()
 }

--- a/crates/iced-longbridge/src/components/time_picker.rs
+++ b/crates/iced-longbridge/src/components/time_picker.rs
@@ -10,7 +10,7 @@ use iced::{
 use crate::{
     components::{
         icon::{icon, IconName},
-        popover::popover,
+        popover::popover_dismissable,
     },
     theme::AppTheme,
 };
@@ -20,6 +20,34 @@ use crate::{
 /// Each column shows the current value with a `+` button above and a `−`
 /// button below. Hours wrap 0–23, minutes and seconds wrap 0–59.
 pub fn time_picker<'a, Message: Clone + 'a>(
+    theme: &AppTheme,
+    time: NaiveTime,
+    show_seconds: bool,
+    on_hour: impl Fn(u32) -> Message + 'a + Copy,
+    on_minute: impl Fn(u32) -> Message + 'a + Copy,
+    on_second: impl Fn(u32) -> Message + 'a + Copy,
+) -> Element<'a, Message> {
+    let t = *theme;
+    container(time_picker_inner(theme, time, show_seconds, on_hour, on_minute, on_second))
+        .padding(Padding::from([12.0, 16.0]))
+        .style(move |_| container::Style {
+            background: Some(Background::Color(t.background)),
+            text_color: Some(t.foreground),
+            border: Border {
+                color: t.border,
+                width: 1.0,
+                radius: 8.0.into(),
+            },
+            shadow: Shadow::default(),
+            snap: true,
+        })
+        .into()
+}
+
+/// The picker row without the outer bordered container — used when the caller
+/// (e.g. [`time_picker_popover`]) already wraps the content in a bordered
+/// popover chrome.
+fn time_picker_inner<'a, Message: Clone + 'a>(
     theme: &AppTheme,
     time: NaiveTime,
     show_seconds: bool,
@@ -46,21 +74,7 @@ pub fn time_picker<'a, Message: Clone + 'a>(
         r = r.push(sep(":"));
         r = r.push(spinner(t, time.second(), 60, on_second));
     }
-
-    container(r)
-        .padding(Padding::from([12.0, 16.0]))
-        .style(move |_| container::Style {
-            background: Some(Background::Color(t.background)),
-            text_color: Some(t.foreground),
-            border: Border {
-                color: t.border,
-                width: 1.0,
-                radius: 8.0.into(),
-            },
-            shadow: Shadow::default(),
-            snap: true,
-        })
-        .into()
+    r.into()
 }
 
 /// Button trigger + anchored picker, mirroring [`date_picker`](super::calendar).
@@ -95,7 +109,7 @@ pub fn time_picker_popover<'a, Message: Clone + 'a>(
         .align_y(Vertical::Center),
     )
     .padding(Padding::from([6.0, 12.0]))
-    .on_press(on_toggle)
+    .on_press(on_toggle.clone())
     .style(move |_, status| {
         use button::Status::*;
         let bg = match status {
@@ -117,8 +131,12 @@ pub fn time_picker_popover<'a, Message: Clone + 'a>(
     })
     .into();
 
-    let panel = open.then(|| time_picker(theme, time, show_seconds, on_hour, on_minute, on_second));
-    popover(theme, trigger, panel)
+    let panel = open.then(|| {
+        container(time_picker_inner(theme, time, show_seconds, on_hour, on_minute, on_second))
+            .padding(Padding::from([6.0, 8.0]))
+            .into()
+    });
+    popover_dismissable(theme, trigger, panel, on_toggle)
 }
 
 fn spinner<'a, Message: Clone + 'a>(


### PR DESCRIPTION
Add FloatingPanel::on_dismiss and a popover_dismissable helper that publishes a message when the user clicks outside a floating panel. Update dropdown_button, color_picker, time_picker and the date picker demo
to use the dismissable popover and fix on_press cloning where needed. Also tweak color picker padding/layout, extract time_picker_inner, and refine floating panel flip behavior