### PR TITLE
refactor(table): builder API, impl Fn callbacks, Column::text shortcut

### DIFF
--- a/crates/demo/src/demos/table_demo.rs
+++ b/crates/demo/src/demos/table_demo.rs
@@ -5,11 +5,11 @@ use iced::{
 };
 
 use crate::{
-    Message, State,
+    Message, SortDir, State,
     components::{
         badge::{badge, BadgeVariant},
         menu::{menu, Item},
-        table::{table_with, Column, ResizeHandlers, SortDir, TableOptions},
+        table::{table, Column},
     },
     demos::common::{section_caption, section_title, vspace},
     lucide,
@@ -48,17 +48,13 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
             .unwrap_or(Length::Fill)
     };
 
-    let name_col = Column::new("Name", move |p: &Person| {
-        text(p.name.to_string()).size(13.0).color(t.foreground).into()
-    })
-    .width(w(0))
-    .sortable("name");
+    let name_col = Column::text("Name", |p: &Person| p.name.to_string())
+        .width(w(0))
+        .sortable("name");
 
-    let role_col = Column::new("Role", move |p: &Person| {
-        text(p.role.to_string()).size(13.0).color(t.muted_foreground).into()
-    })
-    .width(w(1))
-    .sortable("role");
+    let role_col = Column::text("Role", |p: &Person| p.role.to_string())
+        .width(w(1))
+        .sortable("role");
 
     let status_col = Column::new("Status", move |p: &Person| {
         let variant = match p.status {
@@ -71,13 +67,11 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
     .width(w(2))
     .align(Horizontal::Left);
 
-    let mut salary_col = Column::new("Salary", move |p: &Person| {
-        text(format!("${}", fmt_money(p.salary))).size(13.0).color(t.foreground).into()
-    })
-    .width(w(3))
-    .align(Horizontal::Right)
-    .sortable("salary")
-    .header_button(lucide::settings(), Message::TableHeaderButtonToggle(3));
+    let mut salary_col = Column::text("Salary", |p: &Person| format!("${}", fmt_money(p.salary)))
+        .width(w(3))
+        .align(Horizontal::Right)
+        .sortable("salary")
+        .header_button(lucide::settings(), Message::TableHeaderButtonToggle(3));
 
     if state.table_header_menu_open == Some(3) {
         let panel = menu(
@@ -95,30 +89,20 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
         salary_col = salary_col.header_panel(panel);
     }
 
-    let sort = state.table_sort.map(|(k, d)| (k, match d {
-        crate::SortKind::Asc => SortDir::Asc,
-        crate::SortKind::Desc => SortDir::Desc,
-    }));
-
-    let options = TableOptions {
-        sort,
-        on_sort: Some(Box::new(Message::TableSort)),
-        striped: true,
-        row_height: 44.0,
-        resize: Some(ResizeHandlers {
-            on_grab: Box::new(Message::TableResizeStart),
-            on_drag: Box::new(Message::TableResizeMove),
-            on_release: Message::TableResizeEnd,
-            dragging: state.table_resize_col,
-        }),
-    };
-
-    let tbl = table_with(
+    let tbl: Element<Message> = table(
         theme,
         &rows,
         vec![name_col, role_col, status_col, salary_col],
-        options,
-    );
+    )
+    .row_height(44.0)
+    .sort(state.table_sort, Message::TableSort)
+    .resize(
+        state.table_resize_col,
+        Message::TableResizeStart,
+        Message::TableResizeMove,
+        Message::TableResizeEnd,
+    )
+    .into();
 
     column![
         section_title(theme, "Sortable table"),
@@ -144,7 +128,7 @@ fn sorted_rows(state: &State) -> Vec<Person> {
                 "salary" => a.salary.cmp(&b.salary),
                 _ => std::cmp::Ordering::Equal,
             };
-            if matches!(dir, crate::SortKind::Desc) { ord.reverse() } else { ord }
+            if matches!(dir, SortDir::Desc) { ord.reverse() } else { ord }
         });
     }
     v

--- a/crates/demo/src/demos/table_demo.rs
+++ b/crates/demo/src/demos/table_demo.rs
@@ -8,9 +8,11 @@ use crate::{
     Message, State,
     components::{
         badge::{badge, BadgeVariant},
+        menu::{menu, Item},
         table::{table_with, Column, ResizeHandlers, SortDir, TableOptions},
     },
     demos::common::{section_caption, section_title, vspace},
+    lucide,
     theme::AppTheme,
 };
 
@@ -69,12 +71,29 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
     .width(w(2))
     .align(Horizontal::Left);
 
-    let salary_col = Column::new("Salary", move |p: &Person| {
+    let mut salary_col = Column::new("Salary", move |p: &Person| {
         text(format!("${}", fmt_money(p.salary))).size(13.0).color(t.foreground).into()
     })
     .width(w(3))
     .align(Horizontal::Right)
-    .sortable("salary");
+    .sortable("salary")
+    .header_button(lucide::settings(), Message::TableHeaderButtonToggle(3));
+
+    if state.table_header_menu_open == Some(3) {
+        let panel = menu(
+            theme,
+            vec![
+                Item::new("Hide column", Message::TableHeaderMenuAction("hide"))
+                    .icon(lucide::eye_off()),
+                Item::new("Filter…", Message::TableHeaderMenuAction("filter"))
+                    .icon(lucide::filter()),
+                Item::Separator,
+                Item::new("Reset sort", Message::TableHeaderMenuAction("reset_sort"))
+                    .icon(lucide::refresh_cw()),
+            ],
+        );
+        salary_col = salary_col.header_panel(panel);
+    }
 
     let sort = state.table_sort.map(|(k, d)| (k, match d {
         crate::SortKind::Asc => SortDir::Asc,
@@ -105,7 +124,7 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
         section_title(theme, "Sortable table"),
         section_caption(
             theme,
-            "Click a sortable header to toggle asc/desc ordering. Drag a column divider to resize.",
+            "Click a sortable header to toggle ordering. Use the settings button on the Salary header to open a per-column menu. Drag a divider to resize.",
         ),
         tbl,
         vspace(8.0),

--- a/crates/demo/src/lib.rs
+++ b/crates/demo/src/lib.rs
@@ -120,11 +120,7 @@ pub enum Category {
     Charts,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SortKind {
-    Asc,
-    Desc,
-}
+pub use iced_longbridge::components::table::SortDir;
 
 impl Page {
     pub const ALL: &'static [(Page, &'static str, Category)] = &[
@@ -352,7 +348,7 @@ pub struct State {
     pub toggles: [bool; 6],
 
     // Demo state — data
-    pub table_sort: Option<(&'static str, SortKind)>,
+    pub table_sort: Option<(&'static str, SortDir)>,
     pub table_col_widths: Vec<f32>,
     pub table_resize_col: Option<usize>,
     pub table_resize_last_x: Option<f32>,
@@ -701,9 +697,9 @@ pub fn update(state: &mut State, message: Message) -> Task<Message> {
         }
         Message::TableSort(key) => {
             state.table_sort = match state.table_sort {
-                Some((k, SortKind::Asc)) if k == key => Some((key, SortKind::Desc)),
-                Some((k, SortKind::Desc)) if k == key => None,
-                _ => Some((key, SortKind::Asc)),
+                Some((k, SortDir::Asc)) if k == key => Some((key, SortDir::Desc)),
+                Some((k, SortDir::Desc)) if k == key => None,
+                _ => Some((key, SortDir::Asc)),
             };
         }
         Message::TableResizeStart(i) => {

--- a/crates/demo/src/lib.rs
+++ b/crates/demo/src/lib.rs
@@ -273,6 +273,8 @@ pub enum Message {
     TableResizeStart(usize),
     TableResizeMove(iced::Point),
     TableResizeEnd,
+    TableHeaderButtonToggle(usize),
+    TableHeaderMenuAction(&'static str),
     ListSelected(usize),
     TreeToggle(String),
     TreeSelect(String),
@@ -354,6 +356,7 @@ pub struct State {
     pub table_col_widths: Vec<f32>,
     pub table_resize_col: Option<usize>,
     pub table_resize_last_x: Option<f32>,
+    pub table_header_menu_open: Option<usize>,
     pub list_selected: usize,
     pub data_table: crate::components::data_table::DataTable,
     pub tree_nodes: Vec<crate::components::tree::TreeNode>,
@@ -459,6 +462,7 @@ impl Default for State {
             table_col_widths: vec![220.0, 220.0, 140.0, 140.0],
             table_resize_col: None,
             table_resize_last_x: None,
+            table_header_menu_open: None,
             list_selected: 0,
             data_table: build_sample_data_table(),
             tree_nodes: crate::demos::tree_demo::sample_nodes(),
@@ -720,6 +724,17 @@ pub fn update(state: &mut State, message: Message) -> Task<Message> {
         Message::TableResizeEnd => {
             state.table_resize_col = None;
             state.table_resize_last_x = None;
+        }
+        Message::TableHeaderButtonToggle(i) => {
+            state.table_header_menu_open =
+                if state.table_header_menu_open == Some(i) { None } else { Some(i) };
+        }
+        Message::TableHeaderMenuAction(action) => {
+            state.last_action = format!("Table header: {action}");
+            state.table_header_menu_open = None;
+            if action == "reset_sort" {
+                state.table_sort = None;
+            }
         }
         Message::ListSelected(i) => {
             state.list_selected = i;

--- a/crates/iced-longbridge/src/components/button.rs
+++ b/crates/iced-longbridge/src/components/button.rs
@@ -6,8 +6,9 @@ use iced::{
 };
 
 use crate::{
+    components::icon::{icon_colored, Icon},
     styles,
-    theme::{AppTheme, Size},
+    theme::{with_alpha, AppTheme, Size},
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -61,6 +62,36 @@ pub fn button_ex<'a, Message: 'a + Clone>(
         btn = btn.on_press(msg);
     }
 
+    btn.into()
+}
+
+/// Icon-only Ghost button. Transparent by default with a subtle hover
+/// tint. The hover/press backgrounds are translucent foreground so the
+/// effect stays visible whether the button sits on `t.background`,
+/// `t.muted`, or another surface (`Variant::Ghost`'s opaque `t.accent`
+/// hover collides with `t.muted` in this design system, so a generic
+/// icon button needs a surface-agnostic tint).
+pub fn ghost_icon_button<'a, Message: 'a + Clone>(
+    theme: &AppTheme,
+    icon_src: impl Into<Icon>,
+    on_press: Option<Message>,
+) -> Element<'a, Message> {
+    let t = *theme;
+    let content = icon_colored::<Message>(icon_src.into(), 14.0, t.muted_foreground);
+    let mut btn = button(content)
+        .padding(Padding::from([4.0, 6.0]))
+        .style(move |_, status| {
+            use button::Status::*;
+            let bg = match status {
+                Hovered => with_alpha(t.foreground, 0.08),
+                Pressed => with_alpha(t.foreground, 0.14),
+                _ => iced::Color::TRANSPARENT,
+            };
+            styles::button_style(Some(bg), t.foreground, iced::Color::TRANSPARENT, 0.0, 4.0)
+        });
+    if let Some(msg) = on_press {
+        btn = btn.on_press(msg);
+    }
     btn.into()
 }
 

--- a/crates/iced-longbridge/src/components/data_table.rs
+++ b/crates/iced-longbridge/src/components/data_table.rs
@@ -3,11 +3,10 @@
 use iced::{
     Element, Length,
     alignment::Horizontal,
-    widget::text,
 };
 
 use crate::{
-    components::table::{table_with, Column, TableOptions},
+    components::table::{table, Column},
     theme::AppTheme,
 };
 
@@ -44,19 +43,17 @@ pub fn data_table<'a, Message: Clone + 'a>(
     theme: &AppTheme,
     data: &'a DataTable,
 ) -> Element<'a, Message> {
-    let theme_copy = *theme;
     let mut columns: Vec<Column<'a, Vec<String>, Message>> = Vec::with_capacity(data.headers.len());
     for (idx, header) in data.headers.iter().enumerate() {
         let width = data.widths.get(idx).copied().unwrap_or(Length::Fill);
         let align = data.aligns.get(idx).copied().unwrap_or(Horizontal::Left);
         columns.push(
-            Column::new(header.clone(), move |row: &Vec<String>| {
-                let cell = row.get(idx).cloned().unwrap_or_default();
-                text(cell).size(13.0).color(theme_copy.foreground).into()
+            Column::text(header.clone(), move |row: &Vec<String>| {
+                row.get(idx).cloned().unwrap_or_default()
             })
             .width(width)
             .align(align),
         );
     }
-    table_with(theme, &data.rows, columns, TableOptions::default())
+    table(theme, &data.rows, columns).into()
 }

--- a/crates/iced-longbridge/src/components/table.rs
+++ b/crates/iced-longbridge/src/components/table.rs
@@ -27,7 +27,11 @@ use iced::{
 };
 
 use crate::{
-    components::icon::{icon_colored, lucide},
+    components::{
+        button::ghost_icon_button,
+        icon::{icon_colored, lucide, Icon},
+        popover::popover_aligned,
+    },
     theme::AppTheme,
 };
 
@@ -53,6 +57,9 @@ pub struct Column<'a, T, Message> {
     #[allow(clippy::type_complexity)]
     pub render: Box<dyn Fn(&T) -> Element<'a, Message> + 'a>,
     pub sort_key: Option<&'static str>,
+    pub header_button_icon: Option<Icon>,
+    pub header_button_msg: Option<Message>,
+    pub header_panel: Option<Element<'a, Message>>,
 }
 
 impl<'a, T, Message> Column<'a, T, Message> {
@@ -66,6 +73,9 @@ impl<'a, T, Message> Column<'a, T, Message> {
             align: Horizontal::Left,
             render: Box::new(render),
             sort_key: None,
+            header_button_icon: None,
+            header_button_msg: None,
+            header_panel: None,
         }
     }
 
@@ -81,6 +91,23 @@ impl<'a, T, Message> Column<'a, T, Message> {
 
     pub fn sortable(mut self, key: &'static str) -> Self {
         self.sort_key = Some(key);
+        self
+    }
+
+    /// Add an icon button to this column's header. Composed next to the
+    /// title/sort area so it stays independently clickable when the column
+    /// is also `sortable`.
+    pub fn header_button(mut self, icon: impl Into<Icon>, on_press: Message) -> Self {
+        self.header_button_icon = Some(icon.into());
+        self.header_button_msg = Some(on_press);
+        self
+    }
+
+    /// Attach a floating panel (e.g. a `menu()`) anchored beneath the header
+    /// button. The same `on_press` message also fires on outside-click to
+    /// dismiss, so a single toggle message can drive open/close.
+    pub fn header_panel(mut self, panel: impl Into<Element<'a, Message>>) -> Self {
+        self.header_panel = Some(panel.into());
         self
     }
 }
@@ -141,60 +168,19 @@ pub fn table_with<'a, T, Message: Clone + 'a>(
         row_height,
         resize,
     } = options;
+    let mut columns = columns;
     let col_count = columns.len();
 
     // Header row.
     let mut header = row![].spacing(0);
-    for (i, col) in columns.iter().enumerate() {
+    for (i, col) in columns.iter_mut().enumerate() {
         let is_sorted = sort.map(|(k, _)| Some(k) == col.sort_key).unwrap_or(false);
         let sort_dir = if is_sorted { sort.map(|(_, d)| d) } else { None };
 
-        let mut inner = row![text(col.header.clone()).size(12.0).color(t.muted_foreground)]
-            .spacing(6)
-            .align_y(Vertical::Center);
-        if let Some(dir) = sort_dir {
-            inner = inner.push(icon_colored::<Message>(
-                match dir {
-                    SortDir::Asc => lucide::arrow_up_narrow_wide(),
-                    SortDir::Desc => lucide::arrow_down_wide_narrow(),
-                },
-                11.0,
-                t.muted_foreground,
-            ));
-        }
-
-        let cell = container(inner)
-            .padding(Padding::from([0.0, 12.0]))
-            .width(col.width)
-            .height(Length::Fixed(36.0))
-            .align_x(col.align)
-            .align_y(Vertical::Center);
-
-        // Sortable cells are wrapped in a button that emits on_sort.
-        let cell_el: Element<Message> = match (col.sort_key, on_sort.as_ref()) {
-            (Some(key), Some(cb)) => {
-                let msg = cb(key);
-                iced::widget::button(cell)
-                    .padding(0)
-                    .on_press(msg)
-                    .style(move |_, status| {
-                        use iced::widget::button::Status::*;
-                        let bg = match status {
-                            Hovered => t.accent,
-                            Pressed => t.muted,
-                            _ => iced::Color::TRANSPARENT,
-                        };
-                        iced::widget::button::Style {
-                            background: Some(Background::Color(bg)),
-                            text_color: t.foreground,
-                            border: Border::default(),
-                            shadow: Shadow::default(),
-                            snap: true,
-                        }
-                    })
-                    .into()
-            }
-            _ => cell.into(),
+        let cell_el: Element<Message> = if col.header_button_icon.is_some() {
+            build_header_cell_with_button(&t, col, sort_dir, on_sort.as_deref())
+        } else {
+            build_header_cell(&t, col, sort_dir, on_sort.as_deref())
         };
 
         header = header.push(cell_el);
@@ -359,5 +345,171 @@ fn body_divider<'a, Message: 'a>(row_height: f32) -> Element<'a, Message> {
     container(Space::new().width(Length::Fixed(DIVIDER_WIDTH)).height(Length::Fill))
         .width(Length::Fixed(DIVIDER_WIDTH))
         .height(Length::Fixed(row_height))
+        .into()
+}
+
+/// Build a sort-toggle button (or plain title row) for the column header.
+/// Used by `build_header_cell_with_button` so the title click target stays
+/// distinct from the icon button.
+fn build_sort_area<'a, T, Message: Clone + 'a>(
+    t: &AppTheme,
+    col: &Column<'a, T, Message>,
+    sort_dir: Option<SortDir>,
+    on_sort: Option<&(dyn Fn(&'static str) -> Message + 'a)>,
+) -> Element<'a, Message> {
+    let t = *t;
+    let mut inner = row![text(col.header.clone()).size(12.0).color(t.muted_foreground)]
+        .spacing(6)
+        .align_y(Vertical::Center);
+    if let Some(dir) = sort_dir {
+        inner = inner.push(icon_colored::<Message>(
+            match dir {
+                SortDir::Asc => lucide::arrow_up_narrow_wide(),
+                SortDir::Desc => lucide::arrow_down_wide_narrow(),
+            },
+            11.0,
+            t.muted_foreground,
+        ));
+    }
+
+    match (col.sort_key, on_sort) {
+        (Some(key), Some(cb)) => {
+            let msg = cb(key);
+            iced::widget::button(inner)
+                .padding(Padding::from([0.0, 12.0]))
+                .on_press(msg)
+                .style(move |_, status| {
+                    use iced::widget::button::Status::*;
+                    let bg = match status {
+                        Hovered => t.accent,
+                        Pressed => t.muted,
+                        _ => iced::Color::TRANSPARENT,
+                    };
+                    iced::widget::button::Style {
+                        background: Some(Background::Color(bg)),
+                        text_color: t.foreground,
+                        border: Border::default(),
+                        shadow: Shadow::default(),
+                        snap: true,
+                    }
+                })
+                .into()
+        }
+        _ => container(inner)
+            .padding(Padding::from([0.0, 12.0]))
+            .into(),
+    }
+}
+
+/// Header cell layout used when a column has no `header_button`. Kept
+/// behaviour-equivalent to the pre-extension code so existing call sites
+/// render identically.
+fn build_header_cell<'a, T, Message: Clone + 'a>(
+    t: &AppTheme,
+    col: &Column<'a, T, Message>,
+    sort_dir: Option<SortDir>,
+    on_sort: Option<&(dyn Fn(&'static str) -> Message + 'a)>,
+) -> Element<'a, Message> {
+    let t = *t;
+    let mut inner = row![text(col.header.clone()).size(12.0).color(t.muted_foreground)]
+        .spacing(6)
+        .align_y(Vertical::Center);
+    if let Some(dir) = sort_dir {
+        inner = inner.push(icon_colored::<Message>(
+            match dir {
+                SortDir::Asc => lucide::arrow_up_narrow_wide(),
+                SortDir::Desc => lucide::arrow_down_wide_narrow(),
+            },
+            11.0,
+            t.muted_foreground,
+        ));
+    }
+
+    let cell = container(inner)
+        .padding(Padding::from([0.0, 12.0]))
+        .width(col.width)
+        .height(Length::Fixed(36.0))
+        .align_x(col.align)
+        .align_y(Vertical::Center);
+
+    match (col.sort_key, on_sort) {
+        (Some(key), Some(cb)) => {
+            let msg = cb(key);
+            iced::widget::button(cell)
+                .padding(0)
+                .on_press(msg)
+                .style(move |_, status| {
+                    use iced::widget::button::Status::*;
+                    let bg = match status {
+                        Hovered => t.accent,
+                        Pressed => t.muted,
+                        _ => iced::Color::TRANSPARENT,
+                    };
+                    iced::widget::button::Style {
+                        background: Some(Background::Color(bg)),
+                        text_color: t.foreground,
+                        border: Border::default(),
+                        shadow: Shadow::default(),
+                        snap: true,
+                    }
+                })
+                .into()
+        }
+        _ => cell.into(),
+    }
+}
+
+/// Header cell with an icon button (and optional floating panel) composed
+/// next to the title/sort area. The icon button is a sibling of the sort
+/// wrapper — not a child — so each `iced::widget::button` is hit-tested
+/// independently.
+fn build_header_cell_with_button<'a, T, Message: Clone + 'a>(
+    t: &AppTheme,
+    col: &mut Column<'a, T, Message>,
+    sort_dir: Option<SortDir>,
+    on_sort: Option<&(dyn Fn(&'static str) -> Message + 'a)>,
+) -> Element<'a, Message> {
+    let t = *t;
+    let sort_area = build_sort_area(&t, col, sort_dir, on_sort);
+
+    let icon = col.header_button_icon.clone().expect("checked by caller");
+    let msg = col.header_button_msg.clone().expect("checked by caller");
+    let trigger = ghost_icon_button(&t, icon, Some(msg.clone()));
+    let header_btn: Element<'a, Message> = match col.header_panel.take() {
+        Some(panel) => popover_aligned(
+            &t,
+            trigger,
+            Some(panel),
+            Horizontal::Right,
+            Some(msg),
+        ),
+        None => trigger,
+    };
+
+    let inner_row = match col.align {
+        Horizontal::Left => row![
+            sort_area,
+            Space::new().width(Length::Fill),
+            header_btn,
+        ],
+        Horizontal::Right => row![
+            Space::new().width(Length::Fill),
+            sort_area,
+            header_btn,
+        ],
+        Horizontal::Center => row![
+            Space::new().width(Length::Fill),
+            sort_area,
+            Space::new().width(Length::Fill),
+            header_btn,
+        ],
+    }
+    .spacing(0)
+    .align_y(Vertical::Center);
+
+    container(inner_row)
+        .width(col.width)
+        .height(Length::Fixed(36.0))
+        .align_y(Vertical::Center)
         .into()
 }

--- a/crates/iced-longbridge/src/components/table.rs
+++ b/crates/iced-longbridge/src/components/table.rs
@@ -1,14 +1,28 @@
 //! Table — column-and-row layout with typed cells.
 //!
-//! Build columns with [`Column::new`] and render rows from any `Vec<T>` via
-//! [`table`]. Header is a sticky row; body is scrollable.
+//! Build columns with [`Column::new`] (or [`Column::text`] for plain-text
+//! cells) and render rows with the [`table`] builder:
+//!
+//! ```ignore
+//! table(theme, &rows, columns)
+//!     .row_height(44.0)
+//!     .sort(state.sort, Message::Sort)
+//!     .resize(
+//!         state.resize_col,
+//!         Message::ResizeStart,
+//!         Message::ResizeMove,
+//!         Message::ResizeEnd,
+//!     )
+//!     .into()
+//! ```
+//!
+//! Header is a sticky row; body is scrollable.
 //!
 //! ## Resizable columns
 //!
-//! Pass a [`ResizeHandlers`] in [`TableOptions::resize`] to enable drag-to-
-//! resize on the boundary between adjacent columns. The caller owns the
-//! per-column width state (as `Length::Fixed` on each [`Column`]) and updates
-//! it from the emitted messages:
+//! [`Table::resize`] enables drag-to-resize on the boundary between adjacent
+//! columns. The caller owns the per-column width state (as `Length::Fixed` on
+//! each [`Column`]) and updates it from the emitted messages:
 //!
 //! - `on_grab(i)` fires when the user presses on the divider *after* column
 //!   `i` — the caller should record `dragging = Some(i)`.
@@ -21,7 +35,7 @@
 //! handle.
 
 use iced::{
-    Background, Border, Element, Length, Padding, Shadow,
+    Background, Border, Element, Length, Padding, Point, Shadow,
     alignment::{Horizontal, Vertical},
     widget::{column, container, mouse_area, row, scrollable, stack, text, Space},
 };
@@ -44,6 +58,9 @@ const SCROLLBAR_WIDTH: f32 = 10.0;
 /// so header/body columns stay aligned.
 const DIVIDER_WIDTH: f32 = 4.0;
 
+/// Header row height. Matches the body row default for visual balance.
+const HEADER_HEIGHT: f32 = 36.0;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortDir {
     Asc,
@@ -51,22 +68,22 @@ pub enum SortDir {
 }
 
 pub struct Column<'a, T, Message> {
-    pub header: String,
-    pub width: Length,
-    pub align: Horizontal,
+    header: String,
+    width: Length,
+    align: Horizontal,
     #[allow(clippy::type_complexity)]
-    pub render: Box<dyn Fn(&T) -> Element<'a, Message> + 'a>,
-    pub sort_key: Option<&'static str>,
-    pub header_button_icon: Option<Icon>,
-    pub header_button_msg: Option<Message>,
-    pub header_panel: Option<Element<'a, Message>>,
+    render: Box<dyn Fn(&T) -> Element<'a, Message> + 'a>,
+    sort_key: Option<&'static str>,
+    header_button_icon: Option<Icon>,
+    header_button_msg: Option<Message>,
+    header_panel: Option<Element<'a, Message>>,
 }
 
 impl<'a, T, Message> Column<'a, T, Message> {
-    pub fn new(
-        header: impl Into<String>,
-        render: impl Fn(&T) -> Element<'a, Message> + 'a,
-    ) -> Self {
+    pub fn new<F>(header: impl Into<String>, render: F) -> Self
+    where
+        F: Fn(&T) -> Element<'a, Message> + 'a,
+    {
         Self {
             header: header.into(),
             width: Length::Fill,
@@ -77,6 +94,19 @@ impl<'a, T, Message> Column<'a, T, Message> {
             header_button_msg: None,
             header_panel: None,
         }
+    }
+
+    /// Shortcut for the common case: a plain-text cell. The accessor returns
+    /// a `String` rendered at the standard cell size; the row container's
+    /// `text_color` styles the foreground.
+    pub fn text<F>(header: impl Into<String>, accessor: F) -> Self
+    where
+        F: Fn(&T) -> String + 'a,
+        Message: 'a,
+    {
+        Self::new(header, move |row| {
+            iced::widget::text(accessor(row)).size(13.0).into()
+        })
     }
 
     pub fn width(mut self, w: Length) -> Self {
@@ -112,63 +142,118 @@ impl<'a, T, Message> Column<'a, T, Message> {
     }
 }
 
-/// Drag-to-resize wiring for column boundaries. See module docs for the
-/// lifecycle.
-pub struct ResizeHandlers<'a, Message> {
-    /// Mouse-down on the divider between column `i` and `i + 1`.
-    pub on_grab: Box<dyn Fn(usize) -> Message + 'a>,
-    /// Mouse moved while the caller is in a dragging state.
-    pub on_drag: Box<dyn Fn(iced::Point) -> Message + 'a>,
-    /// Mouse released (while dragging).
-    pub on_release: Message,
-    /// Index of the column currently being dragged, or `None` when idle.
-    pub dragging: Option<usize>,
+struct ResizeHandlers<'a, Message> {
+    on_grab: Box<dyn Fn(usize) -> Message + 'a>,
+    on_drag: Box<dyn Fn(Point) -> Message + 'a>,
+    on_release: Message,
+    dragging: Option<usize>,
 }
 
-pub struct TableOptions<'a, Message> {
-    pub sort: Option<(&'static str, SortDir)>,
-    pub on_sort: Option<Box<dyn Fn(&'static str) -> Message + 'a>>,
-    pub striped: bool,
-    pub row_height: f32,
-    pub resize: Option<ResizeHandlers<'a, Message>>,
+/// Builder produced by [`table`]. Configure with the chained methods, then
+/// convert to an `Element` via `.into()`.
+///
+/// `'r` is the rows borrow; `'a` is the lifetime of column closures and other
+/// captured callbacks. The two are kept separate so the produced `Element`
+/// (lifetime `'a`) doesn't appear to borrow `rows`.
+pub struct Table<'r, 'a, T, Message> {
+    theme: AppTheme,
+    rows: &'r [T],
+    columns: Vec<Column<'a, T, Message>>,
+    sort: Option<(&'static str, SortDir)>,
+    on_sort: Option<Box<dyn Fn(&'static str) -> Message + 'a>>,
+    striped: bool,
+    row_height: f32,
+    resize: Option<ResizeHandlers<'a, Message>>,
 }
 
-impl<'a, Message> Default for TableOptions<'a, Message> {
-    fn default() -> Self {
-        Self {
-            sort: None,
-            on_sort: None,
-            striped: true,
-            row_height: 40.0,
-            resize: None,
-        }
+pub fn table<'r, 'a, T, Message>(
+    theme: &AppTheme,
+    rows: &'r [T],
+    columns: Vec<Column<'a, T, Message>>,
+) -> Table<'r, 'a, T, Message> {
+    Table {
+        theme: *theme,
+        rows,
+        columns,
+        sort: None,
+        on_sort: None,
+        striped: true,
+        row_height: 40.0,
+        resize: None,
     }
 }
 
-#[allow(dead_code)]
-pub fn table<'a, T, Message: Clone + 'a>(
-    theme: &AppTheme,
-    rows: &[T],
-    columns: Vec<Column<'a, T, Message>>,
-) -> Element<'a, Message> {
-    table_with(theme, rows, columns, TableOptions::default())
+impl<'r, 'a, T, Message> Table<'r, 'a, T, Message> {
+    pub fn striped(mut self, on: bool) -> Self {
+        self.striped = on;
+        self
+    }
+
+    pub fn row_height(mut self, h: f32) -> Self {
+        self.row_height = h;
+        self
+    }
+
+    /// Wire up sortable columns. `current` is the active sort, or `None` if
+    /// the table is unsorted; `on_sort` fires when the user clicks a sortable
+    /// header.
+    pub fn sort<F>(mut self, current: Option<(&'static str, SortDir)>, on_sort: F) -> Self
+    where
+        F: Fn(&'static str) -> Message + 'a,
+    {
+        self.sort = current;
+        self.on_sort = Some(Box::new(on_sort));
+        self
+    }
+
+    /// Enable drag-to-resize on column boundaries. See the module docs for
+    /// the message lifecycle.
+    pub fn resize<G, D>(
+        mut self,
+        dragging: Option<usize>,
+        on_grab: G,
+        on_drag: D,
+        on_release: Message,
+    ) -> Self
+    where
+        G: Fn(usize) -> Message + 'a,
+        D: Fn(Point) -> Message + 'a,
+    {
+        self.resize = Some(ResizeHandlers {
+            on_grab: Box::new(on_grab),
+            on_drag: Box::new(on_drag),
+            on_release,
+            dragging,
+        });
+        self
+    }
 }
 
-pub fn table_with<'a, T, Message: Clone + 'a>(
-    theme: &AppTheme,
-    rows: &[T],
-    columns: Vec<Column<'a, T, Message>>,
-    options: TableOptions<'a, Message>,
-) -> Element<'a, Message> {
-    let t = *theme;
-    let TableOptions {
+impl<'r, 'a, T, Message> From<Table<'r, 'a, T, Message>> for Element<'a, Message>
+where
+    Message: Clone + 'a,
+    T: 'r,
+{
+    fn from(table: Table<'r, 'a, T, Message>) -> Self {
+        render(table)
+    }
+}
+
+fn render<'r, 'a, T, Message>(table: Table<'r, 'a, T, Message>) -> Element<'a, Message>
+where
+    Message: Clone + 'a,
+    T: 'r,
+{
+    let Table {
+        theme: t,
+        rows,
+        mut columns,
         sort,
         on_sort,
         striped,
         row_height,
         resize,
-    } = options;
-    let mut columns = columns;
+    } = table;
     let col_count = columns.len();
 
     // Header row.
@@ -177,13 +262,7 @@ pub fn table_with<'a, T, Message: Clone + 'a>(
         let is_sorted = sort.map(|(k, _)| Some(k) == col.sort_key).unwrap_or(false);
         let sort_dir = if is_sorted { sort.map(|(_, d)| d) } else { None };
 
-        let cell_el: Element<Message> = if col.header_button_icon.is_some() {
-            build_header_cell_with_button(&t, col, sort_dir, on_sort.as_deref())
-        } else {
-            build_header_cell(&t, col, sort_dir, on_sort.as_deref())
-        };
-
-        header = header.push(cell_el);
+        header = header.push(build_header_cell(&t, col, sort_dir, on_sort.as_deref()));
 
         if i + 1 < col_count {
             header = header.push(header_divider(&t, resize.as_ref(), i));
@@ -194,17 +273,7 @@ pub fn table_with<'a, T, Message: Clone + 'a>(
     let header_bar = container(header)
         .width(Length::Fill)
         .padding(Padding::default().right(SCROLLBAR_WIDTH))
-        .style(move |_| container::Style {
-            background: Some(Background::Color(t.muted)),
-            text_color: Some(t.muted_foreground),
-            border: Border {
-                color: t.border,
-                width: 0.0,
-                radius: 0.0.into(),
-            },
-            shadow: Shadow::default(),
-            snap: true,
-        });
+        .style(move |_| solid_bg(t.muted, t.muted_foreground, t.border));
 
     // Body rows.
     let mut body = column![].spacing(0);
@@ -223,24 +292,11 @@ pub fn table_with<'a, T, Message: Clone + 'a>(
             }
         }
         let zebra = striped && i % 2 == 1;
+        let bg = if zebra { t.muted } else { t.background };
         body = body.push(
             container(r)
                 .width(Length::Fill)
-                .style(move |_| container::Style {
-                    background: Some(Background::Color(if zebra {
-                        t.muted
-                    } else {
-                        t.background
-                    })),
-                    text_color: Some(t.foreground),
-                    border: Border {
-                        color: t.border,
-                        width: 0.0,
-                        radius: 0.0.into(),
-                    },
-                    shadow: Shadow::default(),
-                    snap: true,
-                }),
+                .style(move |_| solid_bg(bg, t.foreground, t.border)),
         );
     }
 
@@ -305,6 +361,20 @@ pub fn table_with<'a, T, Message: Clone + 'a>(
     }
 }
 
+fn solid_bg(bg: iced::Color, fg: iced::Color, border: iced::Color) -> container::Style {
+    container::Style {
+        background: Some(Background::Color(bg)),
+        text_color: Some(fg),
+        border: Border {
+            color: border,
+            width: 0.0,
+            radius: 0.0.into(),
+        },
+        shadow: Shadow::default(),
+        snap: true,
+    }
+}
+
 /// Divider strip between two header cells. Clickable when resize is enabled.
 fn header_divider<'a, Message: Clone + 'a>(
     t: &AppTheme,
@@ -315,7 +385,7 @@ fn header_divider<'a, Message: Clone + 'a>(
     let resizable = resize.is_some();
     let base = container(Space::new().width(Length::Fixed(DIVIDER_WIDTH)).height(Length::Fill))
         .width(Length::Fixed(DIVIDER_WIDTH))
-        .height(Length::Fixed(36.0))
+        .height(Length::Fixed(HEADER_HEIGHT))
         .style(move |_| {
             // Subtle vertical rule; only visible when resize is enabled so the
             // user has an affordance to grab.
@@ -348,17 +418,13 @@ fn body_divider<'a, Message: 'a>(row_height: f32) -> Element<'a, Message> {
         .into()
 }
 
-/// Build a sort-toggle button (or plain title row) for the column header.
-/// Used by `build_header_cell_with_button` so the title click target stays
-/// distinct from the icon button.
-fn build_sort_area<'a, T, Message: Clone + 'a>(
-    t: &AppTheme,
-    col: &Column<'a, T, Message>,
+/// Title row (header text + optional sort arrow).
+fn title_row<'a, Message: 'a>(
+    t: AppTheme,
+    header: &str,
     sort_dir: Option<SortDir>,
-    on_sort: Option<&(dyn Fn(&'static str) -> Message + 'a)>,
-) -> Element<'a, Message> {
-    let t = *t;
-    let mut inner = row![text(col.header.clone()).size(12.0).color(t.muted_foreground)]
+) -> iced::widget::Row<'a, Message> {
+    let mut inner = row![text(header.to_string()).size(12.0).color(t.muted_foreground)]
         .spacing(6)
         .align_y(Vertical::Center);
     if let Some(dir) = sort_dir {
@@ -371,12 +437,25 @@ fn build_sort_area<'a, T, Message: Clone + 'a>(
             t.muted_foreground,
         ));
     }
+    inner
+}
 
-    match (col.sort_key, on_sort) {
+/// Wrap `content` in a sort-toggle button if the column is sortable and
+/// `on_sort` is wired; otherwise return `content` (in a padded container if
+/// `pad` is set).
+fn maybe_sort_button<'a, Message: Clone + 'a>(
+    t: AppTheme,
+    content: Element<'a, Message>,
+    sort_key: Option<&'static str>,
+    on_sort: Option<&(dyn Fn(&'static str) -> Message + 'a)>,
+    button_padding: Padding,
+    fallback_padding: Option<Padding>,
+) -> Element<'a, Message> {
+    match (sort_key, on_sort) {
         (Some(key), Some(cb)) => {
             let msg = cb(key);
-            iced::widget::button(inner)
-                .padding(Padding::from([0.0, 12.0]))
+            iced::widget::button(content)
+                .padding(button_padding)
                 .on_press(msg)
                 .style(move |_, status| {
                     use iced::widget::button::Status::*;
@@ -395,121 +474,77 @@ fn build_sort_area<'a, T, Message: Clone + 'a>(
                 })
                 .into()
         }
-        _ => container(inner)
-            .padding(Padding::from([0.0, 12.0]))
-            .into(),
+        _ => match fallback_padding {
+            Some(p) => container(content).padding(p).into(),
+            None => content,
+        },
     }
 }
 
-/// Header cell layout used when a column has no `header_button`. Kept
-/// behaviour-equivalent to the pre-extension code so existing call sites
-/// render identically.
+/// Build a single header cell. When the column has a `header_button`, the
+/// title/sort area and the icon button are siblings so each is hit-tested
+/// independently; otherwise the whole cell is the sort click target.
 fn build_header_cell<'a, T, Message: Clone + 'a>(
-    t: &AppTheme,
-    col: &Column<'a, T, Message>,
-    sort_dir: Option<SortDir>,
-    on_sort: Option<&(dyn Fn(&'static str) -> Message + 'a)>,
-) -> Element<'a, Message> {
-    let t = *t;
-    let mut inner = row![text(col.header.clone()).size(12.0).color(t.muted_foreground)]
-        .spacing(6)
-        .align_y(Vertical::Center);
-    if let Some(dir) = sort_dir {
-        inner = inner.push(icon_colored::<Message>(
-            match dir {
-                SortDir::Asc => lucide::arrow_up_narrow_wide(),
-                SortDir::Desc => lucide::arrow_down_wide_narrow(),
-            },
-            11.0,
-            t.muted_foreground,
-        ));
-    }
-
-    let cell = container(inner)
-        .padding(Padding::from([0.0, 12.0]))
-        .width(col.width)
-        .height(Length::Fixed(36.0))
-        .align_x(col.align)
-        .align_y(Vertical::Center);
-
-    match (col.sort_key, on_sort) {
-        (Some(key), Some(cb)) => {
-            let msg = cb(key);
-            iced::widget::button(cell)
-                .padding(0)
-                .on_press(msg)
-                .style(move |_, status| {
-                    use iced::widget::button::Status::*;
-                    let bg = match status {
-                        Hovered => t.accent,
-                        Pressed => t.muted,
-                        _ => iced::Color::TRANSPARENT,
-                    };
-                    iced::widget::button::Style {
-                        background: Some(Background::Color(bg)),
-                        text_color: t.foreground,
-                        border: Border::default(),
-                        shadow: Shadow::default(),
-                        snap: true,
-                    }
-                })
-                .into()
-        }
-        _ => cell.into(),
-    }
-}
-
-/// Header cell with an icon button (and optional floating panel) composed
-/// next to the title/sort area. The icon button is a sibling of the sort
-/// wrapper — not a child — so each `iced::widget::button` is hit-tested
-/// independently.
-fn build_header_cell_with_button<'a, T, Message: Clone + 'a>(
     t: &AppTheme,
     col: &mut Column<'a, T, Message>,
     sort_dir: Option<SortDir>,
     on_sort: Option<&(dyn Fn(&'static str) -> Message + 'a)>,
 ) -> Element<'a, Message> {
     let t = *t;
-    let sort_area = build_sort_area(&t, col, sort_dir, on_sort);
+    let title: Element<Message> = title_row(t, &col.header, sort_dir).into();
 
-    let icon = col.header_button_icon.clone().expect("checked by caller");
-    let msg = col.header_button_msg.clone().expect("checked by caller");
-    let trigger = ghost_icon_button(&t, icon, Some(msg.clone()));
-    let header_btn: Element<'a, Message> = match col.header_panel.take() {
-        Some(panel) => popover_aligned(
-            &t,
-            trigger,
-            Some(panel),
-            Horizontal::Right,
-            Some(msg),
-        ),
-        None => trigger,
-    };
+    if col.header_button_icon.is_some() {
+        // Title-only sort button (small click target) + sibling icon button.
+        let sort_area = maybe_sort_button(
+            t,
+            title,
+            col.sort_key,
+            on_sort,
+            Padding::from([0.0, 12.0]),
+            Some(Padding::from([0.0, 12.0])),
+        );
 
-    let inner_row = match col.align {
-        Horizontal::Left => row![
-            sort_area,
-            Space::new().width(Length::Fill),
-            header_btn,
-        ],
-        Horizontal::Right => row![
-            Space::new().width(Length::Fill),
-            sort_area,
-            header_btn,
-        ],
-        Horizontal::Center => row![
-            Space::new().width(Length::Fill),
-            sort_area,
-            Space::new().width(Length::Fill),
-            header_btn,
-        ],
+        let icon = col.header_button_icon.clone().expect("checked above");
+        let msg = col.header_button_msg.clone().expect("paired with icon");
+        let trigger = ghost_icon_button(&t, icon, Some(msg.clone()));
+        let header_btn: Element<'a, Message> = match col.header_panel.take() {
+            Some(panel) => popover_aligned(&t, trigger, Some(panel), Horizontal::Right, Some(msg)),
+            None => trigger,
+        };
+
+        let inner_row = match col.align {
+            Horizontal::Left => row![sort_area, Space::new().width(Length::Fill), header_btn],
+            Horizontal::Right => row![Space::new().width(Length::Fill), sort_area, header_btn],
+            Horizontal::Center => row![
+                Space::new().width(Length::Fill),
+                sort_area,
+                Space::new().width(Length::Fill),
+                header_btn,
+            ],
+        }
+        .spacing(0)
+        .align_y(Vertical::Center);
+
+        container(inner_row)
+            .width(col.width)
+            .height(Length::Fixed(HEADER_HEIGHT))
+            .align_y(Vertical::Center)
+            .into()
+    } else {
+        // Whole cell is the sort click target.
+        let cell = container(title)
+            .padding(Padding::from([0.0, 12.0]))
+            .width(col.width)
+            .height(Length::Fixed(HEADER_HEIGHT))
+            .align_x(col.align)
+            .align_y(Vertical::Center);
+        maybe_sort_button(
+            t,
+            cell.into(),
+            col.sort_key,
+            on_sort,
+            Padding::from(0),
+            None,
+        )
     }
-    .spacing(0)
-    .align_y(Vertical::Center);
-
-    container(inner_row)
-        .width(col.width)
-        .height(Length::Fixed(36.0))
-        .align_y(Vertical::Center)
-        .into()
 }


### PR DESCRIPTION
## Summary
- Replaces `table_with` + `TableOptions` struct with a builder produced by `table()`. Adding new options is now non-breaking and call sites no longer spell out defaults.
- Public callbacks accept `impl Fn` and are boxed internally — call sites lose all the `Box::new(...)` ceremony around `on_sort` and the four resize messages.
- New `Column::text(header, |row| String)` shortcut for the common plain-text cell. The three demo columns that were `text(...).size(13.0).color(t.foreground).into()` now read as one line each.
- Folds `build_header_cell`, `build_header_cell_with_button`, and `build_sort_area` into a single `build_header_cell` plus two shared helpers (`title_row`, `maybe_sort_button`).
- Unifies `SortDir` — demo crate re-exports it from `iced_longbridge::components::table` and drops its own `SortKind` enum + the conversion shim in `table_demo`.

The `Table` builder uses two lifetimes (`'r` for rows, `'a` for column closures) so the resulting `Element<'a, Message>` doesn't appear to borrow `rows` — preserving the original eager-render semantics.

`data_table.rs` and `table_demo.rs` migrated to the new API; `cargo check`, `cargo clippy --no-deps`, and `cargo test` all clean on the workspace.

## Note on commits
This branch is ahead of `origin/master` by two commits — the prior `table header button` commit (was already on local `master`, unpushed) and the refactor itself. The refactor depends on the header-button API, so they ship together.

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy --workspace --no-deps` clean
- [ ] Open the Table demo page and verify: sort toggling, the Salary header settings button + popover menu, drag-to-resize on column dividers, striped rows, empty-state rendering
- [ ] Open the Data table page and verify it still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)