### PR TITLE
fix(table): make resize handles visible in dark mode

### DIFF
--- a/crates/iced-longbridge/src/components/table.rs
+++ b/crates/iced-longbridge/src/components/table.rs
@@ -388,8 +388,14 @@ fn header_divider<'a, Message: Clone + 'a>(
         .height(Length::Fixed(HEADER_HEIGHT))
         .style(move |_| {
             // Subtle vertical rule; only visible when resize is enabled so the
-            // user has an affordance to grab.
-            let bg = if resizable { t.border } else { iced::Color::TRANSPARENT };
+            // user has an affordance to grab. `t.border` collides with the
+            // header's `t.muted` background in dark mode (both 0x26), so use
+            // `muted_foreground` at low alpha for theme-agnostic contrast.
+            let bg = if resizable {
+                iced::Color { a: 0.35, ..t.muted_foreground }
+            } else {
+                iced::Color::TRANSPARENT
+            };
             container::Style {
                 background: Some(Background::Color(bg)),
                 text_color: None,


### PR DESCRIPTION
## Summary
In the dark theme, `t.border` and `t.muted` are both `0x26`, so the resize-divider strip drawn at `border` over the `muted` header bar had zero contrast — the grab affordance was invisible.

Switch the divider color to `t.muted_foreground` at `0.35` alpha. That gives a subtle vertical rule that contrasts against `muted` in both themes without needing per-theme branching.

## Test plan
- [ ] In light mode, dividers still read as a faint vertical rule between header cells (visual parity with before)
- [ ] In dark mode, dividers are now visible and grabbable
- [ ] Hovering shows the resize cursor; drag still resizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)