### PR TITLE
refactor(table): encapsulate resize state behind ResizeState/ResizeEvent

### DIFF
--- a/crates/demo/src/demos/table_demo.rs
+++ b/crates/demo/src/demos/table_demo.rs
@@ -1,5 +1,5 @@
 use iced::{
-    Element, Length,
+    Element,
     alignment::Horizontal,
     widget::{column, text},
 };
@@ -39,21 +39,12 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
     let t = *theme;
     let rows = sorted_rows(state);
 
-    let w = |i: usize| {
-        state
-            .table_col_widths
-            .get(i)
-            .copied()
-            .map(Length::Fixed)
-            .unwrap_or(Length::Fill)
-    };
-
     let name_col = Column::text("Name", |p: &Person| p.name.to_string())
-        .width(w(0))
+        .width(state.table_resize.width(0))
         .sortable("name");
 
     let role_col = Column::text("Role", |p: &Person| p.role.to_string())
-        .width(w(1))
+        .width(state.table_resize.width(1))
         .sortable("role");
 
     let status_col = Column::new("Status", move |p: &Person| {
@@ -64,11 +55,11 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
         };
         badge(&t, p.status.to_string(), variant)
     })
-    .width(w(2))
+    .width(state.table_resize.width(2))
     .align(Horizontal::Left);
 
     let mut salary_col = Column::text("Salary", |p: &Person| format!("${}", fmt_money(p.salary)))
-        .width(w(3))
+        .width(state.table_resize.width(3))
         .align(Horizontal::Right)
         .sortable("salary")
         .header_button(lucide::settings(), Message::TableHeaderButtonToggle(3));
@@ -96,12 +87,7 @@ pub fn view<'a>(state: &'a State, theme: &AppTheme) -> Element<'a, Message> {
     )
     .row_height(44.0)
     .sort(state.table_sort, Message::TableSort)
-    .resize(
-        state.table_resize_col,
-        Message::TableResizeStart,
-        Message::TableResizeMove,
-        Message::TableResizeEnd,
-    )
+    .resize(&state.table_resize, Message::TableResize)
     .into();
 
     column![

--- a/crates/demo/src/lib.rs
+++ b/crates/demo/src/lib.rs
@@ -266,9 +266,7 @@ pub enum Message {
 
     // Data (Phase 3)
     TableSort(&'static str),
-    TableResizeStart(usize),
-    TableResizeMove(iced::Point),
-    TableResizeEnd,
+    TableResize(iced_longbridge::components::table::ResizeEvent),
     TableHeaderButtonToggle(usize),
     TableHeaderMenuAction(&'static str),
     ListSelected(usize),
@@ -349,9 +347,7 @@ pub struct State {
 
     // Demo state — data
     pub table_sort: Option<(&'static str, SortDir)>,
-    pub table_col_widths: Vec<f32>,
-    pub table_resize_col: Option<usize>,
-    pub table_resize_last_x: Option<f32>,
+    pub table_resize: iced_longbridge::components::table::ResizeState,
     pub table_header_menu_open: Option<usize>,
     pub list_selected: usize,
     pub data_table: crate::components::data_table::DataTable,
@@ -455,9 +451,11 @@ impl Default for State {
             button_group: 0,
             toggles: [true, false, false, false, false, false],
             table_sort: None,
-            table_col_widths: vec![220.0, 220.0, 140.0, 140.0],
-            table_resize_col: None,
-            table_resize_last_x: None,
+            table_resize: iced_longbridge::components::table::ResizeState::new(vec![
+                220.0, 220.0, 140.0, 140.0,
+            ])
+            .min_width(60.0)
+            .max_width(600.0),
             table_header_menu_open: None,
             list_selected: 0,
             data_table: build_sample_data_table(),
@@ -702,25 +700,7 @@ pub fn update(state: &mut State, message: Message) -> Task<Message> {
                 _ => Some((key, SortDir::Asc)),
             };
         }
-        Message::TableResizeStart(i) => {
-            state.table_resize_col = Some(i);
-            state.table_resize_last_x = None;
-        }
-        Message::TableResizeMove(pt) => {
-            if let Some(i) = state.table_resize_col {
-                if let Some(last) = state.table_resize_last_x {
-                    let delta = pt.x - last;
-                    if let Some(w) = state.table_col_widths.get_mut(i) {
-                        *w = (*w + delta).clamp(60.0, 600.0);
-                    }
-                }
-                state.table_resize_last_x = Some(pt.x);
-            }
-        }
-        Message::TableResizeEnd => {
-            state.table_resize_col = None;
-            state.table_resize_last_x = None;
-        }
+        Message::TableResize(event) => state.table_resize.apply(event),
         Message::TableHeaderButtonToggle(i) => {
             state.table_header_menu_open =
                 if state.table_header_menu_open == Some(i) { None } else { Some(i) };

--- a/crates/iced-longbridge/src/components/table.rs
+++ b/crates/iced-longbridge/src/components/table.rs
@@ -7,12 +7,7 @@
 //! table(theme, &rows, columns)
 //!     .row_height(44.0)
 //!     .sort(state.sort, Message::Sort)
-//!     .resize(
-//!         state.resize_col,
-//!         Message::ResizeStart,
-//!         Message::ResizeMove,
-//!         Message::ResizeEnd,
-//!     )
+//!     .resize(&state.resize, Message::Resize)
 //!     .into()
 //! ```
 //!
@@ -20,17 +15,22 @@
 //!
 //! ## Resizable columns
 //!
-//! [`Table::resize`] enables drag-to-resize on the boundary between adjacent
-//! columns. The caller owns the per-column width state (as `Length::Fixed` on
-//! each [`Column`]) and updates it from the emitted messages:
+//! [`Table::resize`] enables drag-to-resize on column boundaries. The caller
+//! owns a single [`ResizeState`] value (which carries widths + drag bookkeeping)
+//! and forwards a single [`ResizeEvent`] message back into it:
 //!
-//! - `on_grab(i)` fires when the user presses on the divider *after* column
-//!   `i` — the caller should record `dragging = Some(i)`.
-//! - `on_drag(Point)` fires continuously while the user moves the mouse; the
-//!   caller converts the cursor-x delta to a width change.
-//! - `on_release` fires on mouse-up; the caller clears `dragging`.
+//! ```ignore
+//! // State
+//! pub resize: ResizeState,
 //!
-//! While `dragging.is_some()` the table wraps itself in a full-area mouse
+//! // Update
+//! Message::Resize(event) => state.resize.apply(event),
+//!
+//! // View — read column widths from the state
+//! Column::text("Name", ...).width(state.resize.width(0))
+//! ```
+//!
+//! While a drag is in progress the table wraps itself in a full-area mouse
 //! overlay so the drag keeps working even when the cursor wanders off the
 //! handle.
 
@@ -149,6 +149,92 @@ struct ResizeHandlers<'a, Message> {
     dragging: Option<usize>,
 }
 
+/// Per-column-resize state. Owned by the caller, updated via
+/// [`ResizeState::apply`] from a single message handler.
+#[derive(Debug, Clone)]
+pub struct ResizeState {
+    widths: Vec<f32>,
+    dragging: Option<DragInfo>,
+    min_width: f32,
+    max_width: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DragInfo {
+    col: usize,
+    last_x: Option<f32>,
+}
+
+/// Opaque event emitted by the table during a resize interaction. Forward it
+/// back into [`ResizeState::apply`] from the message handler.
+#[derive(Debug, Clone)]
+pub enum ResizeEvent {
+    Grab(usize),
+    Move(Point),
+    Release,
+}
+
+impl ResizeState {
+    /// Initialize with starting per-column widths (one entry per column).
+    pub fn new(widths: Vec<f32>) -> Self {
+        Self {
+            widths,
+            dragging: None,
+            min_width: 40.0,
+            max_width: f32::INFINITY,
+        }
+    }
+
+    /// Constrain the per-column width during drags. Defaults to `40.0`.
+    pub fn min_width(mut self, w: f32) -> Self {
+        self.min_width = w;
+        self
+    }
+
+    /// Constrain the per-column width during drags. Defaults to unbounded.
+    pub fn max_width(mut self, w: f32) -> Self {
+        self.max_width = w;
+        self
+    }
+
+    /// `Length::Fixed` for the configured column, or `Length::Fill` if the
+    /// index is past the end.
+    pub fn width(&self, col: usize) -> Length {
+        self.widths
+            .get(col)
+            .copied()
+            .map(Length::Fixed)
+            .unwrap_or(Length::Fill)
+    }
+
+    pub fn widths(&self) -> &[f32] {
+        &self.widths
+    }
+
+    /// Apply an event from the table. Call from the message handler.
+    pub fn apply(&mut self, event: ResizeEvent) {
+        match event {
+            ResizeEvent::Grab(col) => {
+                self.dragging = Some(DragInfo { col, last_x: None });
+            }
+            ResizeEvent::Move(p) => {
+                if let Some(drag) = self.dragging.as_mut() {
+                    if let Some(prev) = drag.last_x {
+                        let delta = p.x - prev;
+                        if let Some(w) = self.widths.get_mut(drag.col) {
+                            *w = (*w + delta).clamp(self.min_width, self.max_width);
+                        }
+                    }
+                    drag.last_x = Some(p.x);
+                }
+            }
+            ResizeEvent::Release => {
+                self.dragging = None;
+            }
+        }
+    }
+}
+
 /// Builder produced by [`table`]. Configure with the chained methods, then
 /// convert to an `Element` via `.into()`.
 ///
@@ -206,24 +292,23 @@ impl<'r, 'a, T, Message> Table<'r, 'a, T, Message> {
         self
     }
 
-    /// Enable drag-to-resize on column boundaries. See the module docs for
-    /// the message lifecycle.
-    pub fn resize<G, D>(
-        mut self,
-        dragging: Option<usize>,
-        on_grab: G,
-        on_drag: D,
-        on_release: Message,
-    ) -> Self
+    /// Enable drag-to-resize on column boundaries. The caller owns a
+    /// [`ResizeState`] (typically stored alongside other view state) and
+    /// forwards [`ResizeEvent`]s back into it via `on_event`. See the module
+    /// docs for the full pattern.
+    pub fn resize<F>(mut self, state: &ResizeState, on_event: F) -> Self
     where
-        G: Fn(usize) -> Message + 'a,
-        D: Fn(Point) -> Message + 'a,
+        F: Fn(ResizeEvent) -> Message + 'a,
+        Message: 'a,
     {
+        let on_event = std::rc::Rc::new(on_event);
+        let grab_cb = on_event.clone();
+        let drag_cb = on_event.clone();
         self.resize = Some(ResizeHandlers {
-            on_grab: Box::new(on_grab),
-            on_drag: Box::new(on_drag),
-            on_release,
-            dragging,
+            on_grab: Box::new(move |i| grab_cb(ResizeEvent::Grab(i))),
+            on_drag: Box::new(move |p| drag_cb(ResizeEvent::Move(p))),
+            on_release: on_event(ResizeEvent::Release),
+            dragging: state.dragging.as_ref().map(|d| d.col),
         });
         self
     }


### PR DESCRIPTION
## Summary
The previous `Table::resize` exposed four separate callbacks and asked the caller to maintain three state fields (widths, dragging-column, last-cursor-x) and three message variants. This collapses all of that to one state value and one message:

```rust
// State
pub table_resize: ResizeState,

// Init
ResizeState::new(vec![220.0, 220.0, 140.0, 140.0])
    .min_width(60.0)
    .max_width(600.0)

// Update
Message::TableResize(event) => state.table_resize.apply(event),

// View — read widths from the state, pass it to the table
Column::text(\"Name\", ...).width(state.table_resize.width(0))
// ...
.resize(&state.table_resize, Message::TableResize)
```

`ResizeEvent` is opaque — the caller forwards it to `apply()` without inspecting it. Min/max width clamps are configured on `ResizeState` itself (defaults: `40.0` min, unbounded max), so the table no longer hardcodes per-app constraints.

The internal `ResizeHandlers` shape is unchanged; `Table::resize` wraps the user's single closure in `Rc` once and clones it across the three internal handlers.

## Diff size
- `crates/demo/src/lib.rs`: 3 state fields + 3 message variants + 15 lines of update logic → 1 + 1 + 1.
- `crates/iced-longbridge/src/components/table.rs`: net +67 lines for the public `ResizeState`/`ResizeEvent` API; the previous wiring is gone.

## Test plan
- [ ] Open the Table demo page; drag each column boundary — widths still clamp at 60/600
- [ ] Drag-release while moving the mouse off the divider still works (overlay catcher still active)
- [ ] No regressions in sort, header button, header menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)